### PR TITLE
Support for multiple assignment.

### DIFF
--- a/lib/two/evalctx.py
+++ b/lib/two/evalctx.py
@@ -850,16 +850,13 @@ class EvalPropContext(object):
             target = yield self.execcode_expr_store(target)
 
             # It is also possible to assign to a tuple of targets.
-            if isinstance(target, tuple):
-                if isinstance(val, collections.Sequence):
-                    # value has __len__() and __iter__()
-                    if len(target) == len(val):
-                        for single_target, single_value in zip(target, val):
-                            yield single_target.store(self, self.loctx, single_value)
-                    else:
-                        raise Exception("Number of targets does not match number of values.")
+            if isinstance(target, tuple) and isinstance(val, collections.Sequence):
+                # collections.Sequence subclasses have __len__() and __iter__()
+                if len(target) == len(val):
+                    for single_target, single_value in zip(target, val):
+                        yield single_target.store(self, self.loctx, single_value)
                 else:
-                    raise Exception("Attempting to assing single value to sequence.")
+                    raise Exception("Number of targets does not match number of values.")
             else:
                 yield target.store(self, self.loctx, val)
         return None


### PR DESCRIPTION
While I was neck-deep in assignment actions, I figured I'd implement a few things missing from the assignment statement.

This covers both

```
>>> a = b = c = 3
```

and 

```
>>> a, b, c = 1, 2, 3
```

Augmented assignment supports neither of those forms, so no change is needed there.
